### PR TITLE
Added support to compile the whole stack with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(LALIBE
    VERSION 1.0.0.0
-   LANGUAGES CXX )
+   LANGUAGES CXX C)
 
 # Add path to Lalibe CMake modules
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/configuration)
@@ -10,8 +10,16 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/configuration)
 # Build Options
 option(BUILD_HDF5 "build with hdf5 reading/writing" OFF)
 
+set(Chroma_DIR ${CHROMA_ROOT})
+string(FIND ${CHROMA_ROOT} "cmake" CMAKE_BUILD)
+
 # Find dependencies
-find_package(CHROMA)
+if( ${CMAKE_BUILD} EQUAL "-1" )
+  message("Building with autotools\n")
+  find_package(CHROMA)
+else()
+  find_package(Chroma REQUIRED)
+endif()
 
 # Create lalibe target and add to it main source and
 # config header
@@ -34,17 +42,21 @@ target_include_directories(lalibe PRIVATE ${PROJECT_BINARY_DIR})
 add_subdirectory(lib)
 
 # Find dependencies and link them to lalibe
-find_package(CHROMA)
-if ( CHROMA_FOUND )
-    message("\nCHROMA_ROOT = ${CHROMA_ROOT}\n")
+if( ${CMAKE_BUILD} EQUAL "-1" )
+  find_package(CHROMA)
+  if ( CHROMA_FOUND )
+      message("\nCHROMA_ROOT = ${CHROMA_ROOT}\n")
+  else()
+      message(FATAL_ERROR "we could not find CHROMA_ROOT: ${CHROMA_ROOT}")
+  endif()
+  target_link_libraries(lalibe PRIVATE CHROMA)
+  target_link_libraries(lalibe PRIVATE qio lime)
 else()
-    message(FATAL_ERROR "we could not find CHROMA_ROOT: ${CHROMA_ROOT}")
+  target_link_libraries(lalibe PRIVATE Chroma::chromalib)
 endif()
 
 find_package(OpenMP)
-target_link_libraries(lalibe PRIVATE CHROMA)
 target_link_libraries(lalibe PRIVATE OpenMP::OpenMP_CXX)
-target_link_libraries(lalibe PRIVATE qio lime)
 
 # Compile definitions
 if (BUILD_HDF5)


### PR DESCRIPTION
the `lalibe_fh_proton.h5` file does not pass the check (but also not in `qedm` branch) - this needs to be resolved ultimately with python code to make the same correlator